### PR TITLE
Add Maven publishing configuration for modules

### DIFF
--- a/mariadb/build.gradle
+++ b/mariadb/build.gradle
@@ -1,28 +1,86 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+}
+
+group = 'fr.nassime.helios'
+version = '2.0.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     // Core API dependency
     api project(':api')
-    
+
     // SQL common module dependency
     implementation project(':sql')
-    
+
     // MariaDB specific dependencies
     implementation 'com.zaxxer:HikariCP:5.0.1'
     implementation 'org.mariadb.jdbc:mariadb-java-client:3.3.2'
-    
+
     // Core dependencies
     implementation 'org.jetbrains:annotations:24.1.0'
     implementation 'org.slf4j:slf4j-api:2.0.9'
-    
+
     // Reflection utilities
     implementation 'org.reflections:reflections:0.10.2'
-    
+
     // Lombok for annotations
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
     testCompileOnly 'org.projectlombok:lombok:1.18.30'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
-    
+
     // Test dependencies for MariaDB
     testImplementation 'org.testcontainers:mariadb:1.19.1'
     testImplementation 'org.testcontainers:junit-jupiter:1.19.1'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            artifactId = 'helios-mariadb'
+
+            pom {
+                name = 'Helios ORM MariaDB'
+                description = 'MariaDB implementation for Helios ORM'
+                url = 'https://github.com/na2sime/helios'
+
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://opensource.org/licenses/MIT'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'na2sime'
+                        name = 'Nassime'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:git://github.com/na2sime/helios.git'
+                    developerConnection = 'scm:git:ssh://github.com/na2sime/helios.git'
+                    url = 'https://github.com/na2sime/helios'
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/na2sime/helios")
+            credentials {
+                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
 }

--- a/mongo/build.gradle
+++ b/mongo/build.gradle
@@ -1,15 +1,27 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+}
+
+group = 'fr.nassime.helios'
+version = '2.0.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     // Core API dependency
     api project(':api')
-    
+
     // MongoDB specific dependencies - Updated to latest stable version
     implementation 'org.mongodb:mongodb-driver-sync:5.5.1'
     implementation 'org.mongodb:bson:5.5.1'
-    
+
     // Core dependencies
     implementation 'org.jetbrains:annotations:24.1.0'
     implementation 'org.slf4j:slf4j-api:2.0.9'
-    
+
     // Reflection utilities
     implementation 'org.reflections:reflections:0.10.2'
 
@@ -18,8 +30,54 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
     testCompileOnly 'org.projectlombok:lombok:1.18.30'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
-    
+
     // Test dependencies for MongoDB
     testImplementation 'org.testcontainers:mongodb:1.19.1'
     testImplementation 'org.testcontainers:junit-jupiter:1.19.1'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            artifactId = 'helios-mongo'
+
+            pom {
+                name = 'Helios ORM MongoDB'
+                description = 'MongoDB implementation for Helios ORM'
+                url = 'https://github.com/na2sime/helios'
+
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://opensource.org/licenses/MIT'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'na2sime'
+                        name = 'Nassime'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:git://github.com/na2sime/helios.git'
+                    developerConnection = 'scm:git:ssh://github.com/na2sime/helios.git'
+                    url = 'https://github.com/na2sime/helios'
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/na2sime/helios")
+            credentials {
+                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
 }

--- a/postgres/build.gradle
+++ b/postgres/build.gradle
@@ -1,28 +1,86 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+}
+
+group = 'fr.nassime.helios'
+version = '2.0.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     // Core API dependency
     api project(':api')
-    
+
     // SQL common module dependency
     implementation project(':sql')
-    
+
     // PostgreSQL specific dependencies
     implementation 'com.zaxxer:HikariCP:5.0.1'
     implementation 'org.postgresql:postgresql:42.7.2'
-    
+
     // Core dependencies
     implementation 'org.jetbrains:annotations:24.1.0'
     implementation 'org.slf4j:slf4j-api:2.0.9'
-    
+
     // Reflection utilities
     implementation 'org.reflections:reflections:0.10.2'
-    
+
     // Lombok for annotations
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
     testCompileOnly 'org.projectlombok:lombok:1.18.30'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
-    
+
     // Test dependencies for PostgreSQL
     testImplementation 'org.testcontainers:postgresql:1.19.1'
     testImplementation 'org.testcontainers:junit-jupiter:1.19.1'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            artifactId = 'helios-postgres'
+
+            pom {
+                name = 'Helios ORM PostgreSQL'
+                description = 'PostgreSQL implementation for Helios ORM'
+                url = 'https://github.com/na2sime/helios'
+
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://opensource.org/licenses/MIT'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'na2sime'
+                        name = 'Nassime'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:git://github.com/na2sime/helios.git'
+                    developerConnection = 'scm:git:ssh://github.com/na2sime/helios.git'
+                    url = 'https://github.com/na2sime/helios'
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/na2sime/helios")
+            credentials {
+                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
 }

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'maven-publish'
 }
 
 group = 'fr.nassime.helios'
@@ -34,4 +35,50 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            artifactId = 'helios-sql'
+
+            pom {
+                name = 'Helios ORM SQL'
+                description = 'Common SQL functionality for Helios ORM'
+                url = 'https://github.com/na2sime/helios'
+
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://opensource.org/licenses/MIT'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'na2sime'
+                        name = 'Nassime'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:git://github.com/na2sime/helios.git'
+                    developerConnection = 'scm:git:ssh://github.com/na2sime/helios.git'
+                    url = 'https://github.com/na2sime/helios'
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/na2sime/helios")
+            credentials {
+                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
 }


### PR DESCRIPTION
Setup `maven-publish` plugin for `mongo`, `postgres`, `sql`, and `mariadb` modules. This includes publication metadata, repository configuration, and supporting configurations for GitHub Packages.